### PR TITLE
FFTW Adapter 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ message_benchmark*
 compile_fftw_examples_local.sh
 compile_hpxfft_examples_local.sh
 compile_local.sh
+compile_tests_local.sh

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ We specifically thank the follow contributors:
 ## How To Cite
 
 ```
-@InProceedings{GPRat2025,
+@InProceedings{Strack2024_hpxfft,
   author={Strack, Alexander and Taylor, Christopher and Diehl, Patrick and Pfl{\"u}ger, Dirk},
   title={{Experiences Porting Distributed Applications to Asynchronous Tasks: A Multidimensional FFT Case-study}},
   booktitle={Asynchronous Many-Task Systems and Applications},

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -5,7 +5,8 @@ set(SOURCE_FILES
     src/shared/naive.cpp
     src/shared/agas.cpp
     src/distributed/loop.cpp
-    src/distributed/agas.cpp)
+    src/distributed/agas.cpp
+    src/util/adapter_fftw.cpp)
 
 add_library(hpxfft STATIC ${SOURCE_FILES})
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,7 +6,8 @@ set(SOURCE_FILES
     src/shared/agas.cpp
     src/distributed/loop.cpp
     src/distributed/agas.cpp
-    src/util/adapter_fftw.cpp)
+    src/util/adapter_fftw.cpp
+    src/util/create_dir.cpp)
 
 add_library(hpxfft STATIC ${SOURCE_FILES})
 

--- a/core/include/hpxfft/distributed/agas.hpp
+++ b/core/include/hpxfft/distributed/agas.hpp
@@ -20,7 +20,7 @@ struct agas : hpx::components::client_base<agas, agas_server>
 
     hpx::future<vector_2d> fft_2d_r2c() { return hpx::async(fft_2d_r2c_action(), get_id()); }
 
-    hpx::future<void> initialize(vector_2d values_vec, const std::string COMM_FLAG, const unsigned PLAN_FLAG)
+    hpx::future<void> initialize(vector_2d values_vec, const std::string COMM_FLAG, const std::string PLAN_FLAG)
     {
         return hpx::async(initialize_action(), get_id(), std::move(values_vec), COMM_FLAG, PLAN_FLAG);
     }

--- a/core/include/hpxfft/distributed/agas_server.hpp
+++ b/core/include/hpxfft/distributed/agas_server.hpp
@@ -26,6 +26,8 @@ struct agas_server : hpx::components::component_base<agas_server>
 
     vector_2d fft_2d_r2c();
 
+    ~agas_server() { hpxfft::util::fftw_adapter::cleanup(); }
+
   private:
     // FFT backend
     void fft_1d_r2c_inplace(const std::size_t i);
@@ -66,11 +68,9 @@ struct agas_server : hpx::components::component_base<agas_server>
     std::size_t n_x_local_, n_y_local_;
     std::size_t dim_r_y_, dim_c_y_, dim_c_x_;
     std::size_t dim_c_y_part_, dim_c_x_part_;
-    // FFTW plans
-    hpxfft::util::fftw_plan_flag PLAN_FLAG_;
-    // IMPORTANT: declare r2c adapter before c2c so r2c destructor is called after c2c
-    hpxfft::util::fftw_adapter_r2c fftw_r2c_adapter_;
-    hpxfft::util::fftw_adapter_c2c fftw_c2c_adapter_;
+    // 1D adapters
+    hpxfft::util::fftw_adapter::r2c_1d fft_r2c_adapter_;
+    hpxfft::util::fftw_adapter::c2c_1d fft_c2c_adapter_;
     // value vectors
     vector_2d values_vec_;
     vector_2d trans_values_vec_;

--- a/core/include/hpxfft/distributed/agas_server.hpp
+++ b/core/include/hpxfft/distributed/agas_server.hpp
@@ -2,8 +2,8 @@
 #ifndef hpxfft_distributed_agas_server_H_INCLUDED
 #define hpxfft_distributed_agas_server_H_INCLUDED
 
+#include "../util/adapter_fftw.hpp"
 #include "../util/vector_2d.hpp"  // for hpxfft::util::vector_2d
-#include <fftw3.h>                // for fftw_plan, fftw_destroy_plan, fftw_cleanup, FFTW_FLAGS
 #include <hpx/future.hpp>
 #include <hpx/modules/collectives.hpp>
 #include <hpx/timing/high_resolution_timer.hpp>  // for hpx::chrono::high_resolution_timer
@@ -16,23 +16,15 @@ using vector_2d = hpxfft::util::vector_2d<real>;
 
 struct agas_server : hpx::components::component_base<agas_server>
 {
-    typedef fftw_plan fft_backend_plan;
     typedef std::vector<hpx::future<void>> vector_future;
     typedef std::vector<std::vector<real>> vector_comm;
 
   public:
     agas_server() = default;
 
-    void initialize(vector_2d values_vec, const std::string COMM_FLAG, const unsigned PLAN_FLAG);
+    void initialize(vector_2d values_vec, const std::string COMM_FLAG, const std::string PLAN_FLAG);
 
     vector_2d fft_2d_r2c();
-
-    virtual ~agas_server()
-    {
-        fftw_destroy_plan(plan_1d_r2c_);
-        fftw_destroy_plan(plan_1d_c2c_);
-        fftw_cleanup();
-    }
 
   private:
     // FFT backend
@@ -75,9 +67,10 @@ struct agas_server : hpx::components::component_base<agas_server>
     std::size_t dim_r_y_, dim_c_y_, dim_c_x_;
     std::size_t dim_c_y_part_, dim_c_x_part_;
     // FFTW plans
-    unsigned PLAN_FLAG_;
-    fft_backend_plan plan_1d_r2c_;
-    fft_backend_plan plan_1d_c2c_;
+    hpxfft::util::fftw_plan_flag PLAN_FLAG_;
+    // IMPORTANT: declare r2c adapter before c2c so r2c destructor is called after c2c
+    hpxfft::util::fftw_adapter_r2c fftw_r2c_adapter_;
+    hpxfft::util::fftw_adapter_c2c fftw_c2c_adapter_;
     // value vectors
     vector_2d values_vec_;
     vector_2d trans_values_vec_;

--- a/core/include/hpxfft/distributed/loop.hpp
+++ b/core/include/hpxfft/distributed/loop.hpp
@@ -28,6 +28,8 @@ struct loop
 
     real get_measurement(std::string name);
 
+    ~loop() { hpxfft::util::fftw_adapter::cleanup(); }
+
   private:
     // FFT backend
     void fft_1d_r2c_inplace(const std::size_t i);
@@ -54,11 +56,9 @@ struct loop
     std::size_t n_x_local_, n_y_local_;
     std::size_t dim_r_y_, dim_c_y_, dim_c_x_;
     std::size_t dim_c_y_part_, dim_c_x_part_;
-    // FFTW plans
-    hpxfft::util::fftw_plan_flag PLAN_FLAG_;
-    // IMPORTANT: declare r2c adapter before c2c so r2c destructor is called after c2c
-    hpxfft::util::fftw_adapter_r2c fftw_r2c_adapter_;
-    hpxfft::util::fftw_adapter_c2c fftw_c2c_adapter_;
+    // 1D adapters
+    hpxfft::util::fftw_adapter::r2c_1d fft_r2c_adapter_;
+    hpxfft::util::fftw_adapter::c2c_1d fft_c2c_adapter_;
     // value vectors
     vector_2d values_vec_;
     vector_2d trans_values_vec_;

--- a/core/include/hpxfft/distributed/loop.hpp
+++ b/core/include/hpxfft/distributed/loop.hpp
@@ -2,8 +2,8 @@
 #ifndef hpxfft_distributed_loop_H_INCLUDED
 #define hpxfft_distributed_loop_H_INCLUDED
 
+#include "../util/adapter_fftw.hpp"
 #include "../util/vector_2d.hpp"  // for hpxfft::util::vector_2d
-#include <fftw3.h>                // for fftw_plan, fftw_destroy_plan, fftw_cleanup, FFTW_FLAGS
 #include <hpx/future.hpp>
 #include <hpx/modules/collectives.hpp>
 #include <hpx/timing/high_resolution_timer.hpp>  // for hpx::chrono::high_resolution_timer
@@ -16,25 +16,17 @@ using vector_2d = hpxfft::util::vector_2d<real>;
 
 struct loop
 {
-    typedef fftw_plan fft_backend_plan;
     typedef std::vector<hpx::future<void>> vector_future;
     typedef std::vector<std::vector<real>> vector_comm;
 
   public:
     loop() = default;
 
-    void initialize(vector_2d values_vec, const std::string COMM_FLAG, const unsigned PLAN_FLAG);
+    void initialize(vector_2d values_vec, const std::string COMM_FLAG, const std::string PLAN_FLAG);
 
     vector_2d fft_2d_r2c();
 
     real get_measurement(std::string name);
-
-    ~loop()
-    {
-        fftw_destroy_plan(plan_1d_r2c_);
-        fftw_destroy_plan(plan_1d_c2c_);
-        fftw_cleanup();
-    }
 
   private:
     // FFT backend
@@ -63,9 +55,10 @@ struct loop
     std::size_t dim_r_y_, dim_c_y_, dim_c_x_;
     std::size_t dim_c_y_part_, dim_c_x_part_;
     // FFTW plans
-    unsigned PLAN_FLAG_;
-    fft_backend_plan plan_1d_r2c_;
-    fft_backend_plan plan_1d_c2c_;
+    hpxfft::util::fftw_plan_flag PLAN_FLAG_;
+    // IMPORTANT: declare r2c adapter before c2c so r2c destructor is called after c2c
+    hpxfft::util::fftw_adapter_r2c fftw_r2c_adapter_;
+    hpxfft::util::fftw_adapter_c2c fftw_c2c_adapter_;
     // value vectors
     vector_2d values_vec_;
     vector_2d trans_values_vec_;

--- a/core/include/hpxfft/shared/agas.hpp
+++ b/core/include/hpxfft/shared/agas.hpp
@@ -18,7 +18,7 @@ struct agas : ::hpx::components::client_base<agas, agas_server>
 
     hpx::future<vector_2d> fft_2d_r2c() { return ::hpx::async(fft_2d_r2c_action(), get_id()); }
 
-    hpx::future<void> initialize(vector_2d values_vec, const unsigned PLAN_FLAG)
+    hpx::future<void> initialize(vector_2d values_vec, const std::string PLAN_FLAG)
     {
         return ::hpx::async(initialize_action(), get_id(), std::move(values_vec), PLAN_FLAG);
     }

--- a/core/include/hpxfft/shared/agas_server.hpp
+++ b/core/include/hpxfft/shared/agas_server.hpp
@@ -2,8 +2,8 @@
 #ifndef hpxfft_shared_agas_server_H_INCLUDED
 #define hpxfft_shared_agas_server_H_INCLUDED
 
+#include "../util/adapter_fftw.hpp"
 #include "../util/vector_2d.hpp"  // for hpxfft::util::vector_2d
-#include <fftw3.h>                // for fftw_plan, fftw_destroy_plan, fftw_cleanup, FFTW_FLAGS
 #include <hpx/future.hpp>
 #include <hpx/timing/high_resolution_timer.hpp>  // for hpx::chrono::high_resolution_timer
 
@@ -15,22 +15,14 @@ using vector_2d = hpxfft::util::vector_2d<real>;
 
 struct agas_server : hpx::components::component_base<agas_server>
 {
-    typedef fftw_plan fft_backend_plan;
     typedef std::vector<hpx::future<void>> vector_future;
 
   public:
     agas_server() = default;
 
-    void initialize(vector_2d values_vec, const unsigned PLAN_FLAG);
+    void initialize(vector_2d values_vec, const std::string PLAN_FLAG);
 
     vector_2d fft_2d_r2c();
-
-    virtual ~agas_server()
-    {
-        fftw_destroy_plan(plan_1d_r2c_);
-        fftw_destroy_plan(plan_1d_c2c_);
-        fftw_cleanup();
-    }
 
   private:
     // FFT backend
@@ -49,9 +41,10 @@ struct agas_server : hpx::components::component_base<agas_server>
     // parameters
     std::size_t dim_r_y_, dim_c_y_, dim_c_x_;
     // FFTW plans
-    unsigned PLAN_FLAG_;
-    fft_backend_plan plan_1d_r2c_;
-    fft_backend_plan plan_1d_c2c_;
+    hpxfft::util::fftw_plan_flag PLAN_FLAG_;
+    // IMPORTANT: declare r2c adapter before c2c so r2c destructor is called after c2c
+    hpxfft::util::fftw_adapter_r2c fftw_r2c_adapter_;
+    hpxfft::util::fftw_adapter_c2c fftw_c2c_adapter_;
     // value vectors
     vector_2d values_vec_;
     vector_2d trans_values_vec_;

--- a/core/include/hpxfft/shared/agas_server.hpp
+++ b/core/include/hpxfft/shared/agas_server.hpp
@@ -24,6 +24,8 @@ struct agas_server : hpx::components::component_base<agas_server>
 
     vector_2d fft_2d_r2c();
 
+    ~agas_server() { hpxfft::util::fftw_adapter::cleanup(); }
+
   private:
     // FFT backend
     void fft_1d_r2c_inplace(const std::size_t i);
@@ -40,11 +42,9 @@ struct agas_server : hpx::components::component_base<agas_server>
   private:
     // parameters
     std::size_t dim_r_y_, dim_c_y_, dim_c_x_;
-    // FFTW plans
-    hpxfft::util::fftw_plan_flag PLAN_FLAG_;
-    // IMPORTANT: declare r2c adapter before c2c so r2c destructor is called after c2c
-    hpxfft::util::fftw_adapter_r2c fftw_r2c_adapter_;
-    hpxfft::util::fftw_adapter_c2c fftw_c2c_adapter_;
+    // 1D adapters
+    hpxfft::util::fftw_adapter::r2c_1d fft_r2c_adapter_;
+    hpxfft::util::fftw_adapter::c2c_1d fft_c2c_adapter_;
     // value vectors
     vector_2d values_vec_;
     vector_2d trans_values_vec_;

--- a/core/include/hpxfft/shared/loop.hpp
+++ b/core/include/hpxfft/shared/loop.hpp
@@ -27,6 +27,8 @@ struct loop
 
     void write_plans_to_file(std::string file_path);
 
+    ~loop() { hpxfft::util::fftw_adapter::cleanup(); }
+
   private:
     // FFT backend
     void fft_1d_r2c_inplace(const std::size_t i);
@@ -43,11 +45,9 @@ struct loop
   private:
     // parameters
     std::size_t dim_r_y_, dim_c_y_, dim_c_x_;
-    // FFTW plans
-    hpxfft::util::fftw_plan_flag PLAN_FLAG_;
-    // IMPORTANT: declare r2c adapter before c2c so r2c destructor is called after c2c
-    hpxfft::util::fftw_adapter_r2c fftw_r2c_adapter_;
-    hpxfft::util::fftw_adapter_c2c fftw_c2c_adapter_;
+    // 1D adapters
+    hpxfft::util::fftw_adapter::r2c_1d fft_r2c_adapter_;
+    hpxfft::util::fftw_adapter::c2c_1d fft_c2c_adapter_;
     // value vectors
     vector_2d values_vec_;
     vector_2d trans_values_vec_;

--- a/core/include/hpxfft/shared/loop.hpp
+++ b/core/include/hpxfft/shared/loop.hpp
@@ -2,8 +2,8 @@
 #ifndef hpxfft_shared_loop_H_INCLUDED
 #define hpxfft_shared_loop_H_INCLUDED
 
+#include "../util/adapter_fftw.hpp"
 #include "../util/vector_2d.hpp"                 // for hpxfft::util::vector_2d
-#include <fftw3.h>                               // for fftw_plan, fftw_destroy_plan, fftw_cleanup, FFTW_FLAGS
 #include <hpx/timing/high_resolution_timer.hpp>  // for hpx::chrono::high_resolution_timer
 
 typedef double real;
@@ -14,12 +14,10 @@ using vector_2d = hpxfft::util::vector_2d<real>;
 
 struct loop
 {
-    typedef fftw_plan fft_backend_plan;
-
   public:
     loop() = default;
 
-    void initialize(vector_2d values_vec, const unsigned PLAN_FLAG);
+    void initialize(vector_2d values_vec, const std::string PLAN_FLAG);
 
     vector_2d fft_2d_r2c_par();
 
@@ -28,13 +26,6 @@ struct loop
     real get_measurement(std::string name);
 
     void write_plans_to_file(std::string file_path);
-
-    ~loop()
-    {
-        fftw_destroy_plan(plan_1d_r2c_);
-        fftw_destroy_plan(plan_1d_c2c_);
-        fftw_cleanup();
-    }
 
   private:
     // FFT backend
@@ -53,9 +44,10 @@ struct loop
     // parameters
     std::size_t dim_r_y_, dim_c_y_, dim_c_x_;
     // FFTW plans
-    unsigned PLAN_FLAG_;
-    fft_backend_plan plan_1d_r2c_;
-    fft_backend_plan plan_1d_c2c_;
+    hpxfft::util::fftw_plan_flag PLAN_FLAG_;
+    // IMPORTANT: declare r2c adapter before c2c so r2c destructor is called after c2c
+    hpxfft::util::fftw_adapter_r2c fftw_r2c_adapter_;
+    hpxfft::util::fftw_adapter_c2c fftw_c2c_adapter_;
     // value vectors
     vector_2d values_vec_;
     vector_2d trans_values_vec_;

--- a/core/include/hpxfft/shared/naive.hpp
+++ b/core/include/hpxfft/shared/naive.hpp
@@ -26,6 +26,8 @@ struct naive
 
     real get_measurement(std::string name);
 
+    ~naive() { hpxfft::util::fftw_adapter::cleanup(); }
+
   private:
     // FFT backend
     void fft_1d_r2c_inplace(const std::size_t i);
@@ -44,11 +46,9 @@ struct naive
   private:
     // parameters
     std::size_t dim_r_y_, dim_c_y_, dim_c_x_;
-    // FFTW plans
-    hpxfft::util::fftw_plan_flag PLAN_FLAG_;
-    // IMPORTANT: declare r2c adapter before c2c so r2c destructor is called after c2c
-    hpxfft::util::fftw_adapter_r2c fftw_r2c_adapter_;
-    hpxfft::util::fftw_adapter_c2c fftw_c2c_adapter_;
+    // 1D adapters
+    hpxfft::util::fftw_adapter::r2c_1d fft_r2c_adapter_;
+    hpxfft::util::fftw_adapter::c2c_1d fft_c2c_adapter_;
     // value vectors
     vector_2d values_vec_;
     vector_2d trans_values_vec_;

--- a/core/include/hpxfft/shared/naive.hpp
+++ b/core/include/hpxfft/shared/naive.hpp
@@ -2,8 +2,8 @@
 #ifndef hpxfft_shared_naive_H_INCLUDED
 #define hpxfft_shared_naive_H_INCLUDED
 
+#include "../util/adapter_fftw.hpp"
 #include "../util/vector_2d.hpp"  // for hpxfft::util::vector_2d
-#include <fftw3.h>                // for fftw_plan, fftw_destroy_plan, fftw_cleanup, FFTW_FLAGS
 #include <hpx/future.hpp>
 #include <hpx/timing/high_resolution_timer.hpp>  // for hpx::chrono::high_resolution_timer
 
@@ -15,24 +15,16 @@ using vector_2d = hpxfft::util::vector_2d<real>;
 
 struct naive
 {
-    typedef fftw_plan fft_backend_plan;
     typedef std::vector<hpx::future<void>> vector_future;
 
   public:
     naive() = default;
 
-    void initialize(vector_2d values_vec, const unsigned PLAN_FLAG);
+    void initialize(vector_2d values_vec, const std::string PLAN_FLAG);
 
     vector_2d fft_2d_r2c();
 
     real get_measurement(std::string name);
-
-    ~naive()
-    {
-        fftw_destroy_plan(plan_1d_r2c_);
-        fftw_destroy_plan(plan_1d_c2c_);
-        fftw_cleanup();
-    }
 
   private:
     // FFT backend
@@ -53,9 +45,10 @@ struct naive
     // parameters
     std::size_t dim_r_y_, dim_c_y_, dim_c_x_;
     // FFTW plans
-    unsigned PLAN_FLAG_;
-    fft_backend_plan plan_1d_r2c_;
-    fft_backend_plan plan_1d_c2c_;
+    hpxfft::util::fftw_plan_flag PLAN_FLAG_;
+    // IMPORTANT: declare r2c adapter before c2c so r2c destructor is called after c2c
+    hpxfft::util::fftw_adapter_r2c fftw_r2c_adapter_;
+    hpxfft::util::fftw_adapter_c2c fftw_c2c_adapter_;
     // value vectors
     vector_2d values_vec_;
     vector_2d trans_values_vec_;

--- a/core/include/hpxfft/shared/opt.hpp
+++ b/core/include/hpxfft/shared/opt.hpp
@@ -2,8 +2,8 @@
 #ifndef hpxfft_shared_opt_H_INCLUDED
 #define hpxfft_shared_opt_H_INCLUDED
 
+#include "../util/adapter_fftw.hpp"
 #include "../util/vector_2d.hpp"  // for hpxfft::util::vector_2d
-#include <fftw3.h>                // for fftw_plan, fftw_destroy_plan, fftw_cleanup, FFTW_FLAGS
 #include <hpx/future.hpp>
 #include <hpx/timing/high_resolution_timer.hpp>  // for hpx::chrono::high_resolution_timer
 
@@ -15,24 +15,16 @@ using vector_2d = hpxfft::util::vector_2d<real>;
 
 struct opt
 {
-    typedef fftw_plan fft_backend_plan;
     typedef std::vector<hpx::future<void>> vector_future;
 
   public:
     opt() = default;
 
-    void initialize(vector_2d values_vec, const unsigned PLAN_FLAG);
+    void initialize(vector_2d values_vec, const std::string PLAN_FLAG);
 
     vector_2d fft_2d_r2c();
 
     real get_measurement(std::string name);
-
-    ~opt()
-    {
-        fftw_destroy_plan(plan_1d_r2c_);
-        fftw_destroy_plan(plan_1d_c2c_);
-        fftw_cleanup();
-    }
 
   private:
     // FFT backend
@@ -53,9 +45,10 @@ struct opt
     // parameters
     std::size_t dim_r_y_, dim_c_y_, dim_c_x_;
     // FFTW plans
-    unsigned PLAN_FLAG_;
-    fft_backend_plan plan_1d_r2c_;
-    fft_backend_plan plan_1d_c2c_;
+    hpxfft::util::fftw_plan_flag PLAN_FLAG_;
+    // IMPORTANT: declare r2c adapter before c2c so r2c destructor is called after c2c
+    hpxfft::util::fftw_adapter_r2c fftw_r2c_adapter_;
+    hpxfft::util::fftw_adapter_c2c fftw_c2c_adapter_;
     // value vectors
     vector_2d values_vec_;
     vector_2d trans_values_vec_;

--- a/core/include/hpxfft/shared/opt.hpp
+++ b/core/include/hpxfft/shared/opt.hpp
@@ -26,6 +26,8 @@ struct opt
 
     real get_measurement(std::string name);
 
+    ~opt() { hpxfft::util::fftw_adapter::cleanup(); }
+
   private:
     // FFT backend
     void fft_1d_r2c_inplace(const std::size_t i);
@@ -44,11 +46,9 @@ struct opt
   private:
     // parameters
     std::size_t dim_r_y_, dim_c_y_, dim_c_x_;
-    // FFTW plans
-    hpxfft::util::fftw_plan_flag PLAN_FLAG_;
-    // IMPORTANT: declare r2c adapter before c2c so r2c destructor is called after c2c
-    hpxfft::util::fftw_adapter_r2c fftw_r2c_adapter_;
-    hpxfft::util::fftw_adapter_c2c fftw_c2c_adapter_;
+    // 1D adapters
+    hpxfft::util::fftw_adapter::r2c_1d fft_r2c_adapter_;
+    hpxfft::util::fftw_adapter::c2c_1d fft_c2c_adapter_;
     // value vectors
     vector_2d values_vec_;
     vector_2d trans_values_vec_;

--- a/core/include/hpxfft/shared/sync.hpp
+++ b/core/include/hpxfft/shared/sync.hpp
@@ -26,6 +26,8 @@ struct sync
 
     real get_measurement(std::string name);
 
+    ~sync() { hpxfft::util::fftw_adapter::cleanup(); }
+
   private:
     // FFT backend
     void fft_1d_r2c_inplace(const std::size_t i);
@@ -44,10 +46,9 @@ struct sync
   private:
     // parameters
     std::size_t dim_r_y_, dim_c_y_, dim_c_x_;
-    // FFTW plans
-    hpxfft::util::fftw_plan_flag PLAN_FLAG_;
-    hpxfft::util::fftw_adapter_r2c fftw_r2c_adapter_;
-    hpxfft::util::fftw_adapter_c2c fftw_c2c_adapter_;
+    // 1D adapters
+    hpxfft::util::fftw_adapter::r2c_1d fft_r2c_adapter_;
+    hpxfft::util::fftw_adapter::c2c_1d fft_c2c_adapter_;
     // value vectors
     vector_2d values_vec_;
     vector_2d trans_values_vec_;

--- a/core/include/hpxfft/shared/sync.hpp
+++ b/core/include/hpxfft/shared/sync.hpp
@@ -2,8 +2,8 @@
 #ifndef hpxfft_shared_sync_H_INCLUDED
 #define hpxfft_shared_sync_H_INCLUDED
 
+#include "../util/adapter_fftw.hpp"
 #include "../util/vector_2d.hpp"  // for hpxfft::util::vector_2d
-#include <fftw3.h>                // for fftw_plan, fftw_destroy_plan, fftw_cleanup, FFTW_FLAGS
 #include <hpx/future.hpp>
 #include <hpx/timing/high_resolution_timer.hpp>  // for hpx::chrono::high_resolution_timer
 
@@ -15,24 +15,16 @@ using vector_2d = hpxfft::util::vector_2d<real>;
 
 struct sync
 {
-    typedef fftw_plan fft_backend_plan;
     typedef std::vector<hpx::future<void>> vector_future;
 
   public:
     sync() = default;
 
-    void initialize(vector_2d values_vec, const unsigned PLAN_FLAG);
+    void initialize(vector_2d values_vec, const std::string PLAN_FLAG);
 
     vector_2d fft_2d_r2c();
 
     real get_measurement(std::string name);
-
-    ~sync()
-    {
-        fftw_destroy_plan(plan_1d_r2c_);
-        fftw_destroy_plan(plan_1d_c2c_);
-        fftw_cleanup();
-    }
 
   private:
     // FFT backend
@@ -53,9 +45,9 @@ struct sync
     // parameters
     std::size_t dim_r_y_, dim_c_y_, dim_c_x_;
     // FFTW plans
-    unsigned PLAN_FLAG_;
-    fft_backend_plan plan_1d_r2c_;
-    fft_backend_plan plan_1d_c2c_;
+    hpxfft::util::fftw_plan_flag PLAN_FLAG_;
+    hpxfft::util::fftw_adapter_r2c fftw_r2c_adapter_;
+    hpxfft::util::fftw_adapter_c2c fftw_c2c_adapter_;
     // value vectors
     vector_2d values_vec_;
     vector_2d trans_values_vec_;

--- a/core/include/hpxfft/util/adapter_fftw.hpp
+++ b/core/include/hpxfft/util/adapter_fftw.hpp
@@ -1,0 +1,82 @@
+#ifndef fftw_adapter_H_INCLUDED
+#define fftw_adapter_H_INCLUDED
+
+#include <fftw3.h>
+#include <stdexcept>
+#include <string>
+
+// Enums for fftw integration
+namespace hpxfft::util
+{
+enum class fftw_direction { forward = FFTW_FORWARD, backward = FFTW_BACKWARD };
+
+enum class fftw_plan_flag {
+    estimate = FFTW_ESTIMATE,
+    measure = FFTW_MEASURE,
+    patient = FFTW_PATIENT,
+    exhaustive = FFTW_EXHAUSTIVE
+};
+
+inline fftw_plan_flag string_to_fftw_plan_flag(const std::string &flag_str)
+{
+    if (flag_str == "estimate")
+    {
+        return fftw_plan_flag::estimate;
+    }
+    else if (flag_str == "measure")
+    {
+        return fftw_plan_flag::measure;
+    }
+    else if (flag_str == "patient")
+    {
+        return fftw_plan_flag::patient;
+    }
+    else if (flag_str == "exhaustive")
+    {
+        return fftw_plan_flag::exhaustive;
+    }
+    else
+    {
+        throw std::invalid_argument("Invalid FFTW plan flag string");
+    }
+}
+
+struct fftw_adapter_r2c
+{
+  public:
+    void initialize(int dim_r, fftw_plan_flag plan_flag, double *in, fftw_complex *out);
+
+    void execute_r2c(double *in, fftw_complex *out);
+
+    void flops(double *add, double *mul, double *fma);
+
+    void fprintf_plan(FILE *stream);
+
+    ~fftw_adapter_r2c()
+    {
+        fftw_destroy_plan(plan_1d_r2c_);
+        fftw_cleanup();
+    }
+
+  private:
+    fftw_plan plan_1d_r2c_;
+};
+
+struct fftw_adapter_c2c
+{
+  public:
+    void initialize(int dim_c, fftw_plan_flag plan_flag, fftw_complex *in, fftw_complex *out, fftw_direction direction);
+
+    void execute_c2c(fftw_complex *in, fftw_complex *out);
+
+    void flops(double *add, double *mul, double *fma);
+
+    void fprintf_plan(FILE *stream);
+
+    ~fftw_adapter_c2c() { fftw_destroy_plan(plan_1d_c2c_); }
+
+  private:
+    fftw_plan plan_1d_c2c_;
+};
+}  // namespace hpxfft::util
+#endif  // fftw_adapter_H_INCLUDED

--- a/core/include/hpxfft/util/adapter_fftw.hpp
+++ b/core/include/hpxfft/util/adapter_fftw.hpp
@@ -6,34 +6,36 @@
 #include <string>
 
 // Enums for fftw integration
-namespace hpxfft::util
+namespace hpxfft::util::fftw_adapter
 {
-enum class fftw_direction { forward = FFTW_FORWARD, backward = FFTW_BACKWARD };
+enum class direction { forward = FFTW_FORWARD, backward = FFTW_BACKWARD };
 
-enum class fftw_plan_flag {
+enum class plan_flag {
     estimate = FFTW_ESTIMATE,
     measure = FFTW_MEASURE,
     patient = FFTW_PATIENT,
     exhaustive = FFTW_EXHAUSTIVE
 };
 
-inline fftw_plan_flag string_to_fftw_plan_flag(const std::string &flag_str)
+void cleanup();
+
+inline plan_flag string_to_fftw_plan_flag(const std::string &flag_str)
 {
     if (flag_str == "estimate")
     {
-        return fftw_plan_flag::estimate;
+        return plan_flag::estimate;
     }
     else if (flag_str == "measure")
     {
-        return fftw_plan_flag::measure;
+        return plan_flag::measure;
     }
     else if (flag_str == "patient")
     {
-        return fftw_plan_flag::patient;
+        return plan_flag::patient;
     }
     else if (flag_str == "exhaustive")
     {
-        return fftw_plan_flag::exhaustive;
+        return plan_flag::exhaustive;
     }
     else
     {
@@ -41,42 +43,38 @@ inline fftw_plan_flag string_to_fftw_plan_flag(const std::string &flag_str)
     }
 }
 
-struct fftw_adapter_r2c
+struct r2c_1d
 {
   public:
-    void initialize(int dim_r, fftw_plan_flag plan_flag, double *in, fftw_complex *out);
+    void plan(int dim_r, std::string plan_flag, double *in, fftw_complex *out);
 
-    void execute_r2c(double *in, fftw_complex *out);
+    void execute(double *in, fftw_complex *out);
 
     void flops(double *add, double *mul, double *fma);
 
-    void fprintf_plan(FILE *stream);
+    void print_plan(FILE *stream);
 
-    ~fftw_adapter_r2c()
-    {
-        fftw_destroy_plan(plan_1d_r2c_);
-        fftw_cleanup();
-    }
+    ~r2c_1d() { fftw_destroy_plan(plan_r2c_1d_); }
 
   private:
-    fftw_plan plan_1d_r2c_;
+    fftw_plan plan_r2c_1d_;
 };
 
-struct fftw_adapter_c2c
+struct c2c_1d
 {
   public:
-    void initialize(int dim_c, fftw_plan_flag plan_flag, fftw_complex *in, fftw_complex *out, fftw_direction direction);
+    void plan(int dim_c, std::string plan_flag, fftw_complex *in, fftw_complex *out, fftw_adapter::direction direction);
 
-    void execute_c2c(fftw_complex *in, fftw_complex *out);
+    void execute(fftw_complex *in, fftw_complex *out);
 
     void flops(double *add, double *mul, double *fma);
 
-    void fprintf_plan(FILE *stream);
+    void print_plan(FILE *stream);
 
-    ~fftw_adapter_c2c() { fftw_destroy_plan(plan_1d_c2c_); }
+    ~c2c_1d() { fftw_destroy_plan(plan_c2c_1d_); }
 
   private:
-    fftw_plan plan_1d_c2c_;
+    fftw_plan plan_c2c_1d_;
 };
-}  // namespace hpxfft::util
+}  // namespace hpxfft::util::fftw_adapter
 #endif  // fftw_adapter_H_INCLUDED

--- a/core/include/hpxfft/util/create_dir.hpp
+++ b/core/include/hpxfft/util/create_dir.hpp
@@ -6,21 +6,6 @@
 
 namespace hpxfft::util
 {
-void create_parent_dir(std::filesystem::path file_path)
-{
-    // Create parent directory if does not exist
-    std::filesystem::path dir_path = file_path.parent_path();
-    if (!std::filesystem::exists(dir_path))
-    {
-        if (std::filesystem::create_directories(dir_path))
-        {
-            std::cout << "Directory created: " << dir_path << "\n";
-        }
-        else
-        {
-            throw std::runtime_error("Failed to create directory: " + dir_path.string());
-        }
-    }
-}
+void create_parent_dir(std::filesystem::path file_path);
 }  // namespace hpxfft::util
 #endif  // create_dir_H

--- a/core/include/hpxfft/util/print_vector.hpp
+++ b/core/include/hpxfft/util/print_vector.hpp
@@ -6,8 +6,8 @@
 
 namespace hpxfft::util
 {
-
-void print_vector_2d(const vector_2d<real> &input)
+template <typename T>
+void print_vector_2d(const vector_2d<T> &input)
 {
     const std::string msg = "\n";
 

--- a/core/src/distributed/agas.cpp
+++ b/core/src/distributed/agas.cpp
@@ -19,13 +19,13 @@ HPX_REGISTER_ACTION(initialize_action)
 // FFT backend
 void hpxfft::distributed::agas_server::fft_1d_r2c_inplace(const std::size_t i)
 {
-    fftw_r2c_adapter_.execute_r2c(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
+    fft_r2c_adapter_.execute(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
 }
 
 void hpxfft::distributed::agas_server::fft_1d_c2c_inplace(const std::size_t i)
 {
-    fftw_c2c_adapter_.execute_c2c(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
-                                  reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
+    fft_c2c_adapter_.execute(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
+                             reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
 }
 
 // split data for communication
@@ -325,20 +325,18 @@ void hpxfft::distributed::agas_server::initialize(
         values_prep_[i].resize(n_x_local_ * dim_c_y_part_);
         trans_values_prep_[i].resize(n_y_local_ * dim_c_x_part_);
     }
-    // create fftw plans
-    PLAN_FLAG_ = hpxfft::util::string_to_fftw_plan_flag(PLAN_FLAG);
-    // forward step one: r2c in y-direction
-    fftw_r2c_adapter_ = hpxfft::util::fftw_adapter_r2c();
-    fftw_r2c_adapter_.initialize(
-        dim_r_y_, PLAN_FLAG_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
-    // forward step two: c2c in x-direction
-    fftw_c2c_adapter_ = hpxfft::util::fftw_adapter_c2c();
-    fftw_c2c_adapter_.initialize(
-        dim_c_x_,
-        PLAN_FLAG_,
-        reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        hpxfft::util::fftw_direction::forward);
+    // create FFTW plans
+    // r2c in y-direction
+    fft_r2c_adapter_ = hpxfft::util::fftw_adapter::r2c_1d();
+    fft_r2c_adapter_.plan(
+        dim_r_y_, PLAN_FLAG, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
+    // c2c in x-direction
+    fft_c2c_adapter_ = hpxfft::util::fftw_adapter::c2c_1d();
+    fft_c2c_adapter_.plan(dim_c_x_,
+                          PLAN_FLAG,
+                          reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
+                          reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
+                          hpxfft::util::fftw_adapter::direction::forward);
     // communication specific initialization
     COMM_FLAG_ = COMM_FLAG;
     if (COMM_FLAG_ == "scatter")

--- a/core/src/distributed/agas.cpp
+++ b/core/src/distributed/agas.cpp
@@ -19,14 +19,13 @@ HPX_REGISTER_ACTION(initialize_action)
 // FFT backend
 void hpxfft::distributed::agas_server::fft_1d_r2c_inplace(const std::size_t i)
 {
-    fftw_execute_dft_r2c(plan_1d_r2c_, values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
+    fftw_r2c_adapter_.execute_r2c(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
 }
 
 void hpxfft::distributed::agas_server::fft_1d_c2c_inplace(const std::size_t i)
 {
-    fftw_execute_dft(plan_1d_c2c_,
-                     reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
-                     reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
+    fftw_c2c_adapter_.execute_c2c(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
+                                  reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
 }
 
 // split data for communication
@@ -302,7 +301,7 @@ hpxfft::distributed::vector_2d hpxfft::distributed::agas_server::fft_2d_r2c()
 
 // initialization
 void hpxfft::distributed::agas_server::initialize(
-    hpxfft::distributed::vector_2d values_vec, const std::string COMM_FLAG, const unsigned PLAN_FLAG)
+    hpxfft::distributed::vector_2d values_vec, const std::string COMM_FLAG, const std::string PLAN_FLAG)
 {
     // move data into own structure
     values_vec_ = std::move(values_vec);
@@ -327,17 +326,19 @@ void hpxfft::distributed::agas_server::initialize(
         trans_values_prep_[i].resize(n_y_local_ * dim_c_x_part_);
     }
     // create fftw plans
-    PLAN_FLAG_ = PLAN_FLAG;
+    PLAN_FLAG_ = hpxfft::util::string_to_fftw_plan_flag(PLAN_FLAG);
     // forward step one: r2c in y-direction
-    plan_1d_r2c_ = fftw_plan_dft_r2c_1d(
-        dim_r_y_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)), PLAN_FLAG_);
+    fftw_r2c_adapter_ = hpxfft::util::fftw_adapter_r2c();
+    fftw_r2c_adapter_.initialize(
+        dim_r_y_, PLAN_FLAG_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
     // forward step two: c2c in x-direction
-    plan_1d_c2c_ = fftw_plan_dft_1d(
+    fftw_c2c_adapter_ = hpxfft::util::fftw_adapter_c2c();
+    fftw_c2c_adapter_.initialize(
         dim_c_x_,
+        PLAN_FLAG_,
         reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
         reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        FFTW_FORWARD,
-        PLAN_FLAG_);
+        hpxfft::util::fftw_direction::forward);
     // communication specific initialization
     COMM_FLAG_ = COMM_FLAG;
     if (COMM_FLAG_ == "scatter")

--- a/core/src/distributed/loop.cpp
+++ b/core/src/distributed/loop.cpp
@@ -6,14 +6,13 @@
 // FFT backend
 void hpxfft::distributed::loop::fft_1d_r2c_inplace(const std::size_t i)
 {
-    fftw_execute_dft_r2c(plan_1d_r2c_, values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
+    fftw_r2c_adapter_.execute_r2c(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
 }
 
 void hpxfft::distributed::loop::fft_1d_c2c_inplace(const std::size_t i)
 {
-    fftw_execute_dft(plan_1d_c2c_,
-                     reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
-                     reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
+    fftw_c2c_adapter_.execute_c2c(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
+                                  reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
 }
 
 // split data for communication
@@ -274,7 +273,7 @@ hpxfft::distributed::vector_2d hpxfft::distributed::loop::fft_2d_r2c()
 
 // initialization
 void hpxfft::distributed::loop::initialize(
-    hpxfft::distributed::vector_2d values_vec, const std::string COMM_FLAG, const unsigned PLAN_FLAG)
+    hpxfft::distributed::vector_2d values_vec, const std::string COMM_FLAG, const std::string PLAN_FLAG)
 {
     // move data into own structure
     values_vec_ = std::move(values_vec);
@@ -299,17 +298,19 @@ void hpxfft::distributed::loop::initialize(
         trans_values_prep_[i].resize(n_y_local_ * dim_c_x_part_);
     }
     // create fftw plans
-    PLAN_FLAG_ = PLAN_FLAG;
+    PLAN_FLAG_ = hpxfft::util::string_to_fftw_plan_flag(PLAN_FLAG);
     // forward step one: r2c in y-direction
-    plan_1d_r2c_ = fftw_plan_dft_r2c_1d(
-        dim_r_y_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)), PLAN_FLAG_);
+    fftw_r2c_adapter_ = hpxfft::util::fftw_adapter_r2c();
+    fftw_r2c_adapter_.initialize(
+        dim_r_y_, PLAN_FLAG_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
     // forward step two: c2c in x-direction
-    plan_1d_c2c_ = fftw_plan_dft_1d(
+    fftw_c2c_adapter_ = hpxfft::util::fftw_adapter_c2c();
+    fftw_c2c_adapter_.initialize(
         dim_c_x_,
+        PLAN_FLAG_,
         reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
         reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        FFTW_FORWARD,
-        PLAN_FLAG_);
+        hpxfft::util::fftw_direction::forward);
     // communication specific initialization
     COMM_FLAG_ = COMM_FLAG;
     if (COMM_FLAG_ == "scatter")

--- a/core/src/distributed/loop.cpp
+++ b/core/src/distributed/loop.cpp
@@ -6,13 +6,13 @@
 // FFT backend
 void hpxfft::distributed::loop::fft_1d_r2c_inplace(const std::size_t i)
 {
-    fftw_r2c_adapter_.execute_r2c(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
+    fft_r2c_adapter_.execute(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
 }
 
 void hpxfft::distributed::loop::fft_1d_c2c_inplace(const std::size_t i)
 {
-    fftw_c2c_adapter_.execute_c2c(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
-                                  reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
+    fft_c2c_adapter_.execute(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
+                             reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
 }
 
 // split data for communication
@@ -297,20 +297,18 @@ void hpxfft::distributed::loop::initialize(
         values_prep_[i].resize(n_x_local_ * dim_c_y_part_);
         trans_values_prep_[i].resize(n_y_local_ * dim_c_x_part_);
     }
-    // create fftw plans
-    PLAN_FLAG_ = hpxfft::util::string_to_fftw_plan_flag(PLAN_FLAG);
-    // forward step one: r2c in y-direction
-    fftw_r2c_adapter_ = hpxfft::util::fftw_adapter_r2c();
-    fftw_r2c_adapter_.initialize(
-        dim_r_y_, PLAN_FLAG_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
-    // forward step two: c2c in x-direction
-    fftw_c2c_adapter_ = hpxfft::util::fftw_adapter_c2c();
-    fftw_c2c_adapter_.initialize(
-        dim_c_x_,
-        PLAN_FLAG_,
-        reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        hpxfft::util::fftw_direction::forward);
+    // create FFTW plans
+    // r2c in y-direction
+    fft_r2c_adapter_ = hpxfft::util::fftw_adapter::r2c_1d();
+    fft_r2c_adapter_.plan(
+        dim_r_y_, PLAN_FLAG, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
+    // c2c in x-direction
+    fft_c2c_adapter_ = hpxfft::util::fftw_adapter::c2c_1d();
+    fft_c2c_adapter_.plan(dim_c_x_,
+                          PLAN_FLAG,
+                          reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
+                          reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
+                          hpxfft::util::fftw_adapter::direction::forward);
     // communication specific initialization
     COMM_FLAG_ = COMM_FLAG;
     if (COMM_FLAG_ == "scatter")

--- a/core/src/shared/agas.cpp
+++ b/core/src/shared/agas.cpp
@@ -14,13 +14,13 @@ HPX_REGISTER_ACTION(initialize_action);
 // FFT backend
 void hpxfft::shared::agas_server::fft_1d_r2c_inplace(const std::size_t i)
 {
-    fftw_r2c_adapter_.execute_r2c(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
+    fft_r2c_adapter_.execute(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
 }
 
 void hpxfft::shared::agas_server::fft_1d_c2c_inplace(const std::size_t i)
 {
-    fftw_c2c_adapter_.execute_c2c(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
-                                  reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
+    fft_c2c_adapter_.execute(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
+                             reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
 }
 
 // transpose with write running index
@@ -96,20 +96,18 @@ void hpxfft::shared::agas_server::initialize(hpxfft::shared::vector_2d values_ve
     dim_r_y_ = 2 * dim_c_y_ - 2;
     // resize transposed data structure
     trans_values_vec_ = std::move(hpxfft::shared::vector_2d(dim_c_y_, 2 * dim_c_x_));
-    // create fftw plans
-    PLAN_FLAG_ = hpxfft::util::string_to_fftw_plan_flag(PLAN_FLAG);
+    // create FFTW plans
     // r2c in y-direction
-    fftw_r2c_adapter_ = hpxfft::util::fftw_adapter_r2c();
-    fftw_r2c_adapter_.initialize(
-        dim_r_y_, PLAN_FLAG_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
+    fft_r2c_adapter_ = hpxfft::util::fftw_adapter::r2c_1d();
+    fft_r2c_adapter_.plan(
+        dim_r_y_, PLAN_FLAG, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
     // c2c in x-direction
-    fftw_c2c_adapter_ = hpxfft::util::fftw_adapter_c2c();
-    fftw_c2c_adapter_.initialize(
-        dim_c_x_,
-        PLAN_FLAG_,
-        reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        hpxfft::util::fftw_direction::forward);
+    fft_c2c_adapter_ = hpxfft::util::fftw_adapter::c2c_1d();
+    fft_c2c_adapter_.plan(dim_c_x_,
+                          PLAN_FLAG,
+                          reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
+                          reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
+                          hpxfft::util::fftw_adapter::direction::forward);
     // resize futures
     r2c_futures_.resize(dim_c_x_);
     trans_y_to_x_futures_.resize(dim_c_x_);

--- a/core/src/shared/agas.cpp
+++ b/core/src/shared/agas.cpp
@@ -14,14 +14,13 @@ HPX_REGISTER_ACTION(initialize_action);
 // FFT backend
 void hpxfft::shared::agas_server::fft_1d_r2c_inplace(const std::size_t i)
 {
-    fftw_execute_dft_r2c(plan_1d_r2c_, values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
+    fftw_r2c_adapter_.execute_r2c(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
 }
 
 void hpxfft::shared::agas_server::fft_1d_c2c_inplace(const std::size_t i)
 {
-    fftw_execute_dft(plan_1d_c2c_,
-                     reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
-                     reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
+    fftw_c2c_adapter_.execute_c2c(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
+                                  reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
 }
 
 // transpose with write running index
@@ -87,7 +86,7 @@ hpxfft::shared::vector_2d hpxfft::shared::agas_server::fft_2d_r2c()
 }
 
 // initialization
-void hpxfft::shared::agas_server::initialize(hpxfft::shared::vector_2d values_vec, const unsigned PLAN_FLAG)
+void hpxfft::shared::agas_server::initialize(hpxfft::shared::vector_2d values_vec, const std::string PLAN_FLAG)
 {
     // move data into own data structure
     values_vec_ = std::move(values_vec);
@@ -98,17 +97,19 @@ void hpxfft::shared::agas_server::initialize(hpxfft::shared::vector_2d values_ve
     // resize transposed data structure
     trans_values_vec_ = std::move(hpxfft::shared::vector_2d(dim_c_y_, 2 * dim_c_x_));
     // create fftw plans
-    PLAN_FLAG_ = PLAN_FLAG;
+    PLAN_FLAG_ = hpxfft::util::string_to_fftw_plan_flag(PLAN_FLAG);
     // r2c in y-direction
-    plan_1d_r2c_ = fftw_plan_dft_r2c_1d(
-        dim_r_y_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)), PLAN_FLAG);
+    fftw_r2c_adapter_ = hpxfft::util::fftw_adapter_r2c();
+    fftw_r2c_adapter_.initialize(
+        dim_r_y_, PLAN_FLAG_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
     // c2c in x-direction
-    plan_1d_c2c_ = fftw_plan_dft_1d(
+    fftw_c2c_adapter_ = hpxfft::util::fftw_adapter_c2c();
+    fftw_c2c_adapter_.initialize(
         dim_c_x_,
+        PLAN_FLAG_,
         reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
         reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        FFTW_FORWARD,
-        PLAN_FLAG);
+        hpxfft::util::fftw_direction::forward);
     // resize futures
     r2c_futures_.resize(dim_c_x_);
     trans_y_to_x_futures_.resize(dim_c_x_);

--- a/core/src/shared/loop.cpp
+++ b/core/src/shared/loop.cpp
@@ -5,13 +5,13 @@
 // FFT backend
 void hpxfft::shared::loop::fft_1d_r2c_inplace(const std::size_t i)
 {
-    fftw_r2c_adapter_.execute_r2c(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
+    fft_r2c_adapter_.execute(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
 }
 
 void hpxfft::shared::loop::fft_1d_c2c_inplace(const std::size_t i)
 {
-    fftw_c2c_adapter_.execute_c2c(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
-                                  reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
+    fft_c2c_adapter_.execute(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
+                             reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
 }
 
 // transpose with write running index
@@ -166,27 +166,25 @@ void hpxfft::shared::loop::initialize(vector_2d values_vec, const std::string PL
     // resize transposed data structure
     trans_values_vec_ = std::move(vector_2d(dim_c_y_, 2 * dim_c_x_));
     // create FFTW plans
-    PLAN_FLAG_ = hpxfft::util::string_to_fftw_plan_flag(PLAN_FLAG);
-    // compute 1D FFTW plans
     auto start_plan = t_.now();
     // r2c in y-direction
-    fftw_r2c_adapter_ = hpxfft::util::fftw_adapter_r2c();
-    fftw_r2c_adapter_.initialize(
-        dim_r_y_, PLAN_FLAG_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
-    fftw_c2c_adapter_ = hpxfft::util::fftw_adapter_c2c();
-    fftw_c2c_adapter_.initialize(
-        dim_c_x_,
-        PLAN_FLAG_,
-        reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        hpxfft::util::fftw_direction::forward);
+    fft_r2c_adapter_ = hpxfft::util::fftw_adapter::r2c_1d();
+    fft_r2c_adapter_.plan(
+        dim_r_y_, PLAN_FLAG, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
+    // c2c in x-direction
+    fft_c2c_adapter_ = hpxfft::util::fftw_adapter::c2c_1d();
+    fft_c2c_adapter_.plan(dim_c_x_,
+                          PLAN_FLAG,
+                          reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
+                          reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
+                          hpxfft::util::fftw_adapter::direction::forward);
     auto stop_plan = t_.now();
     measurements_["plan"] = stop_plan - start_plan;
     // compute overall plan flops
     double add_r2c, mul_r2c, fma_r2c;
-    fftw_r2c_adapter_.flops(&add_r2c, &mul_r2c, &fma_r2c);
+    fft_r2c_adapter_.flops(&add_r2c, &mul_r2c, &fma_r2c);
     double add_c2c, mul_c2c, fma_c2c;
-    fftw_c2c_adapter_.flops(&add_c2c, &mul_c2c, &fma_c2c);
+    fft_c2c_adapter_.flops(&add_c2c, &mul_c2c, &fma_c2c);
     measurements_["plan_flops"] = dim_r_y_ * (add_r2c + mul_r2c + fma_r2c) + dim_c_x_ * (add_c2c + mul_c2c + fma_c2c);
 }
 
@@ -203,11 +201,11 @@ void hpxfft::shared::loop::write_plans_to_file(std::string file_path)
     }
     // Write first plan
     fprintf(file_name, "FFTW r2c 1D plan:\n");
-    fftw_r2c_adapter_.fprintf_plan(file_name);
+    fft_r2c_adapter_.print_plan(file_name);
     fprintf(file_name, "\n");
     // Write second plan
     fprintf(file_name, "FFTW c2c 1D plan:\n");
-    fftw_c2c_adapter_.fprintf_plan(file_name);
+    fft_c2c_adapter_.print_plan(file_name);
     fprintf(file_name, "\n\n");
     // Close file
     fclose(file_name);

--- a/core/src/shared/loop.cpp
+++ b/core/src/shared/loop.cpp
@@ -5,14 +5,13 @@
 // FFT backend
 void hpxfft::shared::loop::fft_1d_r2c_inplace(const std::size_t i)
 {
-    fftw_execute_dft_r2c(plan_1d_r2c_, values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
+    fftw_r2c_adapter_.execute_r2c(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
 }
 
 void hpxfft::shared::loop::fft_1d_c2c_inplace(const std::size_t i)
 {
-    fftw_execute_dft(plan_1d_c2c_,
-                     reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
-                     reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
+    fftw_c2c_adapter_.execute_c2c(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
+                                  reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
 }
 
 // transpose with write running index
@@ -156,7 +155,7 @@ hpxfft::shared::vector_2d hpxfft::shared::loop::fft_2d_r2c_seq()
 }
 
 // initialization
-void hpxfft::shared::loop::initialize(vector_2d values_vec, const unsigned PLAN_FLAG)
+void hpxfft::shared::loop::initialize(vector_2d values_vec, const std::string PLAN_FLAG)
 {
     // move data into own data structure
     values_vec_ = std::move(values_vec);
@@ -167,26 +166,27 @@ void hpxfft::shared::loop::initialize(vector_2d values_vec, const unsigned PLAN_
     // resize transposed data structure
     trans_values_vec_ = std::move(vector_2d(dim_c_y_, 2 * dim_c_x_));
     // create FFTW plans
-    PLAN_FLAG_ = PLAN_FLAG;
+    PLAN_FLAG_ = hpxfft::util::string_to_fftw_plan_flag(PLAN_FLAG);
     // compute 1D FFTW plans
     auto start_plan = t_.now();
     // r2c in y-direction
-    plan_1d_r2c_ = fftw_plan_dft_r2c_1d(
-        dim_r_y_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)), PLAN_FLAG);
-    // c2c in x-direction
-    plan_1d_c2c_ = fftw_plan_dft_1d(
+    fftw_r2c_adapter_ = hpxfft::util::fftw_adapter_r2c();
+    fftw_r2c_adapter_.initialize(
+        dim_r_y_, PLAN_FLAG_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
+    fftw_c2c_adapter_ = hpxfft::util::fftw_adapter_c2c();
+    fftw_c2c_adapter_.initialize(
         dim_c_x_,
+        PLAN_FLAG_,
         reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
         reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        FFTW_FORWARD,
-        PLAN_FLAG);
+        hpxfft::util::fftw_direction::forward);
     auto stop_plan = t_.now();
     measurements_["plan"] = stop_plan - start_plan;
     // compute overall plan flops
     double add_r2c, mul_r2c, fma_r2c;
-    fftw_flops(plan_1d_r2c_, &add_r2c, &mul_r2c, &fma_r2c);
+    fftw_r2c_adapter_.flops(&add_r2c, &mul_r2c, &fma_r2c);
     double add_c2c, mul_c2c, fma_c2c;
-    fftw_flops(plan_1d_c2c_, &add_c2c, &mul_c2c, &fma_c2c);
+    fftw_c2c_adapter_.flops(&add_c2c, &mul_c2c, &fma_c2c);
     measurements_["plan_flops"] = dim_r_y_ * (add_r2c + mul_r2c + fma_r2c) + dim_c_x_ * (add_c2c + mul_c2c + fma_c2c);
 }
 
@@ -203,11 +203,11 @@ void hpxfft::shared::loop::write_plans_to_file(std::string file_path)
     }
     // Write first plan
     fprintf(file_name, "FFTW r2c 1D plan:\n");
-    fftw_fprint_plan(plan_1d_r2c_, file_name);
+    fftw_r2c_adapter_.fprintf_plan(file_name);
     fprintf(file_name, "\n");
     // Write second plan
     fprintf(file_name, "FFTW c2c 1D plan:\n");
-    fftw_fprint_plan(plan_1d_c2c_, file_name);
+    fftw_c2c_adapter_.fprintf_plan(file_name);
     fprintf(file_name, "\n\n");
     // Close file
     fclose(file_name);

--- a/core/src/shared/naive.cpp
+++ b/core/src/shared/naive.cpp
@@ -3,14 +3,13 @@
 // FFT backend
 void hpxfft::shared::naive::fft_1d_r2c_inplace(const std::size_t i)
 {
-    fftw_execute_dft_r2c(plan_1d_r2c_, values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
+    fftw_r2c_adapter_.execute_r2c(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
 }
 
 void hpxfft::shared::naive::fft_1d_c2c_inplace(const std::size_t i)
 {
-    fftw_execute_dft(plan_1d_c2c_,
-                     reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
-                     reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
+    fftw_c2c_adapter_.execute_c2c(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
+                                  reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
 }
 
 // transpose with read running index
@@ -95,7 +94,7 @@ hpxfft::shared::vector_2d hpxfft::shared::naive::fft_2d_r2c()
 }
 
 // initialization
-void hpxfft::shared::naive::initialize(hpxfft::shared::vector_2d values_vec, const unsigned PLAN_FLAG)
+void hpxfft::shared::naive::initialize(hpxfft::shared::vector_2d values_vec, const std::string PLAN_FLAG)
 {
     // move data into own data structure
     values_vec_ = std::move(values_vec);
@@ -106,17 +105,19 @@ void hpxfft::shared::naive::initialize(hpxfft::shared::vector_2d values_vec, con
     // resize transposed data structure
     trans_values_vec_ = std::move(hpxfft::shared::vector_2d(dim_c_y_, 2 * dim_c_x_));
     // create FFTW plans
-    PLAN_FLAG_ = PLAN_FLAG;
+    PLAN_FLAG_ = hpxfft::util::string_to_fftw_plan_flag(PLAN_FLAG);
     // r2c in y-direction
-    plan_1d_r2c_ = fftw_plan_dft_r2c_1d(
-        dim_r_y_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)), PLAN_FLAG);
+    fftw_r2c_adapter_ = hpxfft::util::fftw_adapter_r2c();
+    fftw_r2c_adapter_.initialize(
+        dim_r_y_, PLAN_FLAG_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
     // c2c in x-direction
-    plan_1d_c2c_ = fftw_plan_dft_1d(
+    fftw_c2c_adapter_ = hpxfft::util::fftw_adapter_c2c();
+    fftw_c2c_adapter_.initialize(
         dim_c_x_,
+        PLAN_FLAG_,
         reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
         reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        FFTW_FORWARD,
-        PLAN_FLAG);
+        hpxfft::util::fftw_direction::forward);
     // resize futures
     r2c_futures_.resize(dim_c_x_);
     trans_y_to_x_futures_.resize(dim_c_x_);

--- a/core/src/shared/opt.cpp
+++ b/core/src/shared/opt.cpp
@@ -3,13 +3,13 @@
 // FFT backend
 void hpxfft::shared::opt::fft_1d_r2c_inplace(const std::size_t i)
 {
-    fftw_r2c_adapter_.execute_r2c(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
+    fft_r2c_adapter_.execute(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
 }
 
 void hpxfft::shared::opt::fft_1d_c2c_inplace(const std::size_t i)
 {
-    fftw_c2c_adapter_.execute_c2c(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
-                                  reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
+    fft_c2c_adapter_.execute(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
+                             reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
 }
 
 // transpose with write running index
@@ -107,19 +107,17 @@ void hpxfft::shared::opt::initialize(hpxfft::shared::vector_2d values_vec, const
     // resize transposed data structure
     trans_values_vec_ = std::move(hpxfft::shared::vector_2d(dim_c_y_, 2 * dim_c_x_));
     // create FFTW plans
-    PLAN_FLAG_ = hpxfft::util::string_to_fftw_plan_flag(PLAN_FLAG);
     // r2c in y-direction
-    fftw_r2c_adapter_ = hpxfft::util::fftw_adapter_r2c();
-    fftw_r2c_adapter_.initialize(
-        dim_r_y_, PLAN_FLAG_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
+    fft_r2c_adapter_ = hpxfft::util::fftw_adapter::r2c_1d();
+    fft_r2c_adapter_.plan(
+        dim_r_y_, PLAN_FLAG, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
     // c2c in x-direction
-    fftw_c2c_adapter_ = hpxfft::util::fftw_adapter_c2c();
-    fftw_c2c_adapter_.initialize(
-        dim_c_x_,
-        PLAN_FLAG_,
-        reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        hpxfft::util::fftw_direction::forward);
+    fft_c2c_adapter_ = hpxfft::util::fftw_adapter::c2c_1d();
+    fft_c2c_adapter_.plan(dim_c_x_,
+                          PLAN_FLAG,
+                          reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
+                          reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
+                          hpxfft::util::fftw_adapter::direction::forward);
     // resize futures
     r2c_futures_.resize(dim_c_x_);
     trans_y_to_x_futures_.resize(dim_c_x_);

--- a/core/src/shared/sync.cpp
+++ b/core/src/shared/sync.cpp
@@ -3,13 +3,13 @@
 // FFT backend
 void hpxfft::shared::sync::fft_1d_r2c_inplace(const std::size_t i)
 {
-    fftw_r2c_adapter_.execute_r2c(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
+    fft_r2c_adapter_.execute(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
 }
 
 void hpxfft::shared::sync::fft_1d_c2c_inplace(const std::size_t i)
 {
-    fftw_c2c_adapter_.execute_c2c(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
-                                  reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
+    fft_c2c_adapter_.execute(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
+                             reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
 }
 
 // transpose with write running index
@@ -108,19 +108,17 @@ void hpxfft::shared::sync::initialize(hpxfft::shared::vector_2d values_vec, cons
     // resize transposed data structure
     trans_values_vec_ = std::move(hpxfft::shared::vector_2d(dim_c_y_, 2 * dim_c_x_));
     // create FFTW plans
-    PLAN_FLAG_ = hpxfft::util::string_to_fftw_plan_flag(PLAN_FLAG);
     // r2c in y-direction
-    fftw_r2c_adapter_ = hpxfft::util::fftw_adapter_r2c();
-    fftw_r2c_adapter_.initialize(
-        dim_r_y_, PLAN_FLAG_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
+    fft_r2c_adapter_ = hpxfft::util::fftw_adapter::r2c_1d();
+    fft_r2c_adapter_.plan(
+        dim_r_y_, PLAN_FLAG, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
     // c2c in x-direction
-    fftw_c2c_adapter_ = hpxfft::util::fftw_adapter_c2c();
-    fftw_c2c_adapter_.initialize(
-        dim_c_x_,
-        PLAN_FLAG_,
-        reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        hpxfft::util::fftw_direction::forward);
+    fft_c2c_adapter_ = hpxfft::util::fftw_adapter::c2c_1d();
+    fft_c2c_adapter_.plan(dim_c_x_,
+                          PLAN_FLAG,
+                          reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
+                          reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
+                          hpxfft::util::fftw_adapter::direction::forward);
     // resize futures
     r2c_futures_.resize(dim_c_x_);
     trans_y_to_x_futures_.resize(dim_c_x_);

--- a/core/src/shared/sync.cpp
+++ b/core/src/shared/sync.cpp
@@ -3,14 +3,13 @@
 // FFT backend
 void hpxfft::shared::sync::fft_1d_r2c_inplace(const std::size_t i)
 {
-    fftw_execute_dft_r2c(plan_1d_r2c_, values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
+    fftw_r2c_adapter_.execute_r2c(values_vec_.row(i), reinterpret_cast<fftw_complex *>(values_vec_.row(i)));
 }
 
 void hpxfft::shared::sync::fft_1d_c2c_inplace(const std::size_t i)
 {
-    fftw_execute_dft(plan_1d_c2c_,
-                     reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
-                     reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
+    fftw_c2c_adapter_.execute_c2c(reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)),
+                                  reinterpret_cast<fftw_complex *>(trans_values_vec_.row(i)));
 }
 
 // transpose with write running index
@@ -98,7 +97,7 @@ hpxfft::shared::vector_2d hpxfft::shared::sync::fft_2d_r2c()
 }
 
 // initialization
-void hpxfft::shared::sync::initialize(hpxfft::shared::vector_2d values_vec, const unsigned PLAN_FLAG)
+void hpxfft::shared::sync::initialize(hpxfft::shared::vector_2d values_vec, const std::string PLAN_FLAG)
 {
     // move data into own data structure
     values_vec_ = std::move(values_vec);
@@ -109,17 +108,19 @@ void hpxfft::shared::sync::initialize(hpxfft::shared::vector_2d values_vec, cons
     // resize transposed data structure
     trans_values_vec_ = std::move(hpxfft::shared::vector_2d(dim_c_y_, 2 * dim_c_x_));
     // create FFTW plans
-    PLAN_FLAG_ = PLAN_FLAG;
+    PLAN_FLAG_ = hpxfft::util::string_to_fftw_plan_flag(PLAN_FLAG);
     // r2c in y-direction
-    plan_1d_r2c_ = fftw_plan_dft_r2c_1d(
-        dim_r_y_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)), PLAN_FLAG);
+    fftw_r2c_adapter_ = hpxfft::util::fftw_adapter_r2c();
+    fftw_r2c_adapter_.initialize(
+        dim_r_y_, PLAN_FLAG_, trans_values_vec_.row(0), reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)));
     // c2c in x-direction
-    plan_1d_c2c_ = fftw_plan_dft_1d(
+    fftw_c2c_adapter_ = hpxfft::util::fftw_adapter_c2c();
+    fftw_c2c_adapter_.initialize(
         dim_c_x_,
+        PLAN_FLAG_,
         reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
         reinterpret_cast<fftw_complex *>(trans_values_vec_.row(0)),
-        FFTW_FORWARD,
-        PLAN_FLAG);
+        hpxfft::util::fftw_direction::forward);
     // resize futures
     r2c_futures_.resize(dim_c_x_);
     trans_y_to_x_futures_.resize(dim_c_x_);

--- a/core/src/util/adapter_fftw.cpp
+++ b/core/src/util/adapter_fftw.cpp
@@ -1,39 +1,42 @@
 #include "../../include/hpxfft/util/adapter_fftw.hpp"
 
 // FFTW adapter implementation
-void hpxfft::util::fftw_adapter_r2c::initialize(int dim_r, fftw_plan_flag plan_flag, double *in, fftw_complex *out)
+void hpxfft::util::fftw_adapter::cleanup() { fftw_cleanup(); }
+
+void hpxfft::util::fftw_adapter::r2c_1d::plan(int dim_r, std::string plan_flag, double *in, fftw_complex *out)
 {
-    // create FFTW plans
-    plan_1d_r2c_ = fftw_plan_dft_r2c_1d(dim_r, in, out, static_cast<unsigned>(plan_flag));
+    // create FFTW plan
+    plan_r2c_1d_ = fftw_plan_dft_r2c_1d(dim_r, in, out, static_cast<unsigned>(string_to_fftw_plan_flag(plan_flag)));
 }
 
-void hpxfft::util::fftw_adapter_r2c::execute_r2c(double *in, fftw_complex *out)
+void hpxfft::util::fftw_adapter::r2c_1d::execute(double *in, fftw_complex *out)
 {
-    fftw_execute_dft_r2c(plan_1d_r2c_, in, out);
+    fftw_execute_dft_r2c(plan_r2c_1d_, in, out);
 }
 
-void hpxfft::util::fftw_adapter_r2c::flops(double *add, double *mul, double *fma)
+void hpxfft::util::fftw_adapter::r2c_1d::flops(double *add, double *mul, double *fma)
 {
-    fftw_flops(plan_1d_r2c_, add, mul, fma);
+    fftw_flops(plan_r2c_1d_, add, mul, fma);
 }
 
-void hpxfft::util::fftw_adapter_r2c::fprintf_plan(FILE *stream) { fftw_fprint_plan(plan_1d_r2c_, stream); }
+void hpxfft::util::fftw_adapter::r2c_1d::print_plan(FILE *stream) { fftw_fprint_plan(plan_r2c_1d_, stream); }
 
-void hpxfft::util::fftw_adapter_c2c::initialize(
-    int dim_c, fftw_plan_flag plan_flag, fftw_complex *in, fftw_complex *out, fftw_direction direction)
+void hpxfft::util::fftw_adapter::c2c_1d::plan(
+    int dim_c, std::string plan_flag, fftw_complex *in, fftw_complex *out, fftw_adapter::direction direction)
 {
-    // create FFTW plans
-    plan_1d_c2c_ = fftw_plan_dft_1d(dim_c, in, out, static_cast<int>(direction), static_cast<unsigned>(plan_flag));
+    // create FFTW plan
+    plan_c2c_1d_ = fftw_plan_dft_1d(
+        dim_c, in, out, static_cast<int>(direction), static_cast<unsigned>(string_to_fftw_plan_flag(plan_flag)));
 }
 
-void hpxfft::util::fftw_adapter_c2c::execute_c2c(fftw_complex *in, fftw_complex *out)
+void hpxfft::util::fftw_adapter::c2c_1d::execute(fftw_complex *in, fftw_complex *out)
 {
-    fftw_execute_dft(plan_1d_c2c_, in, out);
+    fftw_execute_dft(plan_c2c_1d_, in, out);
 }
 
-void hpxfft::util::fftw_adapter_c2c::flops(double *add, double *mul, double *fma)
+void hpxfft::util::fftw_adapter::c2c_1d::flops(double *add, double *mul, double *fma)
 {
-    fftw_flops(plan_1d_c2c_, add, mul, fma);
+    fftw_flops(plan_c2c_1d_, add, mul, fma);
 }
 
-void hpxfft::util::fftw_adapter_c2c::fprintf_plan(FILE *stream) { fftw_fprint_plan(plan_1d_c2c_, stream); }
+void hpxfft::util::fftw_adapter::c2c_1d::print_plan(FILE *stream) { fftw_fprint_plan(plan_c2c_1d_, stream); }

--- a/core/src/util/adapter_fftw.cpp
+++ b/core/src/util/adapter_fftw.cpp
@@ -1,0 +1,39 @@
+#include "../../include/hpxfft/util/adapter_fftw.hpp"
+
+// FFTW adapter implementation
+void hpxfft::util::fftw_adapter_r2c::initialize(int dim_r, fftw_plan_flag plan_flag, double *in, fftw_complex *out)
+{
+    // create FFTW plans
+    plan_1d_r2c_ = fftw_plan_dft_r2c_1d(dim_r, in, out, static_cast<unsigned>(plan_flag));
+}
+
+void hpxfft::util::fftw_adapter_r2c::execute_r2c(double *in, fftw_complex *out)
+{
+    fftw_execute_dft_r2c(plan_1d_r2c_, in, out);
+}
+
+void hpxfft::util::fftw_adapter_r2c::flops(double *add, double *mul, double *fma)
+{
+    fftw_flops(plan_1d_r2c_, add, mul, fma);
+}
+
+void hpxfft::util::fftw_adapter_r2c::fprintf_plan(FILE *stream) { fftw_fprint_plan(plan_1d_r2c_, stream); }
+
+void hpxfft::util::fftw_adapter_c2c::initialize(
+    int dim_c, fftw_plan_flag plan_flag, fftw_complex *in, fftw_complex *out, fftw_direction direction)
+{
+    // create FFTW plans
+    plan_1d_c2c_ = fftw_plan_dft_1d(dim_c, in, out, static_cast<int>(direction), static_cast<unsigned>(plan_flag));
+}
+
+void hpxfft::util::fftw_adapter_c2c::execute_c2c(fftw_complex *in, fftw_complex *out)
+{
+    fftw_execute_dft(plan_1d_c2c_, in, out);
+}
+
+void hpxfft::util::fftw_adapter_c2c::flops(double *add, double *mul, double *fma)
+{
+    fftw_flops(plan_1d_c2c_, add, mul, fma);
+}
+
+void hpxfft::util::fftw_adapter_c2c::fprintf_plan(FILE *stream) { fftw_fprint_plan(plan_1d_c2c_, stream); }

--- a/core/src/util/create_dir.cpp
+++ b/core/src/util/create_dir.cpp
@@ -1,0 +1,18 @@
+#include "../../include/hpxfft/util/create_dir.hpp"
+
+void hpxfft::util::create_parent_dir(std::filesystem::path file_path)
+{
+    // Create parent directory if does not exist
+    std::filesystem::path dir_path = file_path.parent_path();
+    if (!std::filesystem::exists(dir_path))
+    {
+        if (std::filesystem::create_directories(dir_path))
+        {
+            std::cout << "Directory created: " << dir_path << "\n";
+        }
+        else
+        {
+            throw std::runtime_error("Failed to create directory: " + dir_path.string());
+        }
+    }
+}

--- a/examples/hpxfft/distributed_agas_2d.cpp
+++ b/examples/hpxfft/distributed_agas_2d.cpp
@@ -1,7 +1,7 @@
-#include "hpxfft/distributed/agas.hpp"      // for hpxfft::distributed::agas, hpxfft::distributed::vector_2d
-#include "hpxfft/util/create_dir.hpp"       // for hpxfft::util::create_parent_dir
-#include "hpxfft/util/print_vector_2d.hpp"  // for hpxfft::util::print_vector_2d
-#include <fstream>                          // for std::ofstream
+#include "hpxfft/distributed/agas.hpp"   // for hpxfft::distributed::agas, hpxfft::distributed::vector_2d
+#include "hpxfft/util/create_dir.hpp"    // for hpxfft::util::create_parent_dir
+#include "hpxfft/util/print_vector.hpp"  // for hpxfft::util::print_vector_2d
+#include <fstream>                       // for std::ofstream
 #include <hpx/hpx_init.hpp>
 #include <numeric>  // for std::iota
 

--- a/examples/hpxfft/distributed_agas_2d.cpp
+++ b/examples/hpxfft/distributed_agas_2d.cpp
@@ -23,21 +23,6 @@ int hpx_main(hpx::program_options::variables_map &vm)
     const std::size_t dim_c_y = dim_r_y / 2 + 1;
     // division parameter
     const std::size_t n_x_local = dim_c_x / num_localities;
-    ;
-    // FFTW plans
-    unsigned FFT_BACKEND_PLAN_FLAG = FFTW_ESTIMATE;
-    if (plan_flag == "measure")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_MEASURE;
-    }
-    else if (plan_flag == "patient")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_PATIENT;
-    }
-    else if (plan_flag == "exhaustive")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_EXHAUSTIVE;
-    }
 
     ////////////////////////////////////////////////////////////////
     // Initialization
@@ -54,8 +39,7 @@ int hpx_main(hpx::program_options::variables_map &vm)
     // Computation
     hpxfft::distributed::agas fft_computer;
     auto start_total = t.now();
-    hpx::future<void> future_initialize =
-        fft_computer.initialize(std::move(values_vec), run_flag, FFT_BACKEND_PLAN_FLAG);
+    hpx::future<void> future_initialize = fft_computer.initialize(std::move(values_vec), run_flag, plan_flag);
     future_initialize.get();
     auto stop_init = t.now();
     hpx::future<hpxfft::distributed::vector_2d> future_result = fft_computer.fft_2d_r2c();

--- a/examples/hpxfft/distributed_loop_2d.cpp
+++ b/examples/hpxfft/distributed_loop_2d.cpp
@@ -1,7 +1,7 @@
-#include "hpxfft/distributed/loop.hpp"      // for hpxfft::distributed::loop, hpxfft::distributed::vector_2d
-#include "hpxfft/util/create_dir.hpp"       // for hpxfft::util::create_parent_dir
-#include "hpxfft/util/print_vector_2d.hpp"  // for hpxfft::util::print_vector_2d
-#include <fstream>                          // for std::ofstream
+#include "hpxfft/distributed/loop.hpp"   // for hpxfft::distributed::loop, hpxfft::distributed::vector_2d
+#include "hpxfft/util/create_dir.hpp"    // for hpxfft::util::create_parent_dir
+#include "hpxfft/util/print_vector.hpp"  // for hpxfft::util::print_vector_2d
+#include <fstream>                       // for std::ofstream
 #include <hpx/hpx_init.hpp>
 #include <numeric>  // for std::iota
 

--- a/examples/hpxfft/distributed_loop_2d.cpp
+++ b/examples/hpxfft/distributed_loop_2d.cpp
@@ -23,21 +23,6 @@ int hpx_main(hpx::program_options::variables_map &vm)
     const std::size_t dim_c_y = dim_r_y / 2 + 1;
     // division parameter
     const std::size_t n_x_local = dim_c_x / num_localities;
-    ;
-    // FFTW plans
-    unsigned FFT_BACKEND_PLAN_FLAG = FFTW_ESTIMATE;
-    if (plan_flag == "measure")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_MEASURE;
-    }
-    else if (plan_flag == "patient")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_PATIENT;
-    }
-    else if (plan_flag == "exhaustive")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_EXHAUSTIVE;
-    }
 
     ////////////////////////////////////////////////////////////////
     // Initialization
@@ -54,7 +39,7 @@ int hpx_main(hpx::program_options::variables_map &vm)
     // Computation
     hpxfft::distributed::loop fft_computer;
     auto start_total = t.now();
-    fft_computer.initialize(std::move(values_vec), run_flag, FFT_BACKEND_PLAN_FLAG);
+    fft_computer.initialize(std::move(values_vec), run_flag, plan_flag);
     auto stop_init = t.now();
     values_vec = fft_computer.fft_2d_r2c();
     auto stop_total = t.now();

--- a/examples/hpxfft/shared_agas_2d.cpp
+++ b/examples/hpxfft/shared_agas_2d.cpp
@@ -1,7 +1,7 @@
-#include "hpxfft/shared/agas.hpp"           // for hpxfft::shared::agas, hpxfft::shared::vector_2d
-#include "hpxfft/util/create_dir.hpp"       // for hpxfft::util::create_parent_dir
-#include "hpxfft/util/print_vector_2d.hpp"  // for hpxfft::util::print_vector_2d
-#include <fstream>                          // for std::ofstream
+#include "hpxfft/shared/agas.hpp"        // for hpxfft::shared::agas, hpxfft::shared::vector_2d
+#include "hpxfft/util/create_dir.hpp"    // for hpxfft::util::create_parent_dir
+#include "hpxfft/util/print_vector.hpp"  // for hpxfft::util::print_vector_2d
+#include <fstream>                       // for std::ofstream
 #include <hpx/hpx_init.hpp>
 #include <numeric>  // for std::iota
 

--- a/examples/hpxfft/shared_agas_2d.cpp
+++ b/examples/hpxfft/shared_agas_2d.cpp
@@ -26,20 +26,6 @@ int hpx_main(hpx::program_options::variables_map &vm)
     const std::size_t dim_c_x = vm["nx"].as<std::size_t>();  // N_X;
     const std::size_t dim_r_y = vm["ny"].as<std::size_t>();  // N_Y;
     const std::size_t dim_c_y = dim_r_y / 2 + 1;
-    // FFTW plans
-    unsigned FFT_BACKEND_PLAN_FLAG = FFTW_ESTIMATE;
-    if (plan_flag == "measure")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_MEASURE;
-    }
-    else if (plan_flag == "patient")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_PATIENT;
-    }
-    else if (plan_flag == "exhaustive")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_EXHAUSTIVE;
-    }
 
     ////////////////////////////////////////////////////////////////
     // Initialization
@@ -56,7 +42,7 @@ int hpx_main(hpx::program_options::variables_map &vm)
     // Computation
     hpxfft::shared::agas fft_computer;
     auto start_total = t.now();
-    hpx::future<void> future_initialize = fft_computer.initialize(std::move(values_vec), FFT_BACKEND_PLAN_FLAG);
+    hpx::future<void> future_initialize = fft_computer.initialize(std::move(values_vec), plan_flag);
     future_initialize.get();
     auto stop_init = t.now();
     hpx::future<hpxfft::shared::vector_2d> future_result = fft_computer.fft_2d_r2c();

--- a/examples/hpxfft/shared_loop_2d.cpp
+++ b/examples/hpxfft/shared_loop_2d.cpp
@@ -27,20 +27,6 @@ int hpx_main(hpx::program_options::variables_map &vm)
     const std::size_t dim_c_x = vm["nx"].as<std::size_t>();  // N_X;
     const std::size_t dim_r_y = vm["ny"].as<std::size_t>();  // N_Y;
     const std::size_t dim_c_y = dim_r_y / 2 + 1;
-    // FFTW plans
-    unsigned FFT_BACKEND_PLAN_FLAG = FFTW_ESTIMATE;
-    if (plan_flag == "measure")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_MEASURE;
-    }
-    else if (plan_flag == "patient")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_PATIENT;
-    }
-    else if (plan_flag == "exhaustive")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_EXHAUSTIVE;
-    }
 
     ////////////////////////////////////////////////////////////////
     // Initialization
@@ -57,7 +43,7 @@ int hpx_main(hpx::program_options::variables_map &vm)
     // Computation
     hpxfft::shared::loop fft_computer;
     auto start_total = t.now();
-    fft_computer.initialize(std::move(values_vec), FFT_BACKEND_PLAN_FLAG);
+    fft_computer.initialize(std::move(values_vec), plan_flag);
     auto stop_init = t.now();
     if (run_flag == "seq")
     {

--- a/examples/hpxfft/shared_loop_2d.cpp
+++ b/examples/hpxfft/shared_loop_2d.cpp
@@ -1,7 +1,7 @@
-#include "hpxfft/shared/loop.hpp"           // for hpxfft::shared::loop, hpxfft::shared::vector_2d
-#include "hpxfft/util/create_dir.hpp"       // for hpxfft::util::create_parent_dir
-#include "hpxfft/util/print_vector_2d.hpp"  // for hpxfft::util::print_vector_2d
-#include <fstream>                          // for std::ofstream
+#include "hpxfft/shared/loop.hpp"        // for hpxfft::shared::loop, hpxfft::shared::vector_2d
+#include "hpxfft/util/create_dir.hpp"    // for hpxfft::util::create_parent_dir
+#include "hpxfft/util/print_vector.hpp"  // for hpxfft::util::print_vector_2d
+#include <fstream>                       // for std::ofstream
 #include <hpx/hpx_init.hpp>
 #include <numeric>  // for std::iota
 

--- a/examples/hpxfft/shared_naive_2d.cpp
+++ b/examples/hpxfft/shared_naive_2d.cpp
@@ -1,7 +1,7 @@
-#include "hpxfft/shared/naive.hpp"          // for hpxfft::shared::naive, hpxfft::shared::vector_2d
-#include "hpxfft/util/create_dir.hpp"       // for hpxfft::util::create_parent_dir
-#include "hpxfft/util/print_vector_2d.hpp"  // for hpxfft::util::print_vector_2d
-#include <fstream>                          // for std::ofstream
+#include "hpxfft/shared/naive.hpp"       // for hpxfft::shared::naive, hpxfft::shared::vector_2d
+#include "hpxfft/util/create_dir.hpp"    // for hpxfft::util::create_parent_dir
+#include "hpxfft/util/print_vector.hpp"  // for hpxfft::util::print_vector_2d
+#include <fstream>                       // for std::ofstream
 #include <hpx/hpx_init.hpp>
 #include <numeric>  // for std::iota
                     //

--- a/examples/hpxfft/shared_naive_2d.cpp
+++ b/examples/hpxfft/shared_naive_2d.cpp
@@ -27,20 +27,6 @@ int hpx_main(hpx::program_options::variables_map &vm)
     const std::size_t dim_c_x = vm["nx"].as<std::size_t>();  // N_X;
     const std::size_t dim_r_y = vm["ny"].as<std::size_t>();  // N_Y;
     const std::size_t dim_c_y = dim_r_y / 2 + 1;
-    // FFTW plans
-    unsigned FFT_BACKEND_PLAN_FLAG = FFTW_ESTIMATE;
-    if (plan_flag == "measure")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_MEASURE;
-    }
-    else if (plan_flag == "patient")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_PATIENT;
-    }
-    else if (plan_flag == "exhaustive")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_EXHAUSTIVE;
-    }
 
     ////////////////////////////////////////////////////////////////
     // Initialization
@@ -57,7 +43,7 @@ int hpx_main(hpx::program_options::variables_map &vm)
     // Computation
     hpxfft::shared::naive fft_computer;
     auto start_total = t.now();
-    fft_computer.initialize(std::move(values_vec), FFT_BACKEND_PLAN_FLAG);
+    fft_computer.initialize(std::move(values_vec), plan_flag);
     auto stop_init = t.now();
     values_vec = fft_computer.fft_2d_r2c();
     auto stop_total = t.now();

--- a/examples/hpxfft/shared_opt_2d.cpp
+++ b/examples/hpxfft/shared_opt_2d.cpp
@@ -26,20 +26,6 @@ int hpx_main(hpx::program_options::variables_map &vm)
     const std::size_t dim_c_x = vm["nx"].as<std::size_t>();  // N_X;
     const std::size_t dim_r_y = vm["ny"].as<std::size_t>();  // N_Y;
     const std::size_t dim_c_y = dim_r_y / 2 + 1;
-    // FFTW plans
-    unsigned FFT_BACKEND_PLAN_FLAG = FFTW_ESTIMATE;
-    if (plan_flag == "measure")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_MEASURE;
-    }
-    else if (plan_flag == "patient")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_PATIENT;
-    }
-    else if (plan_flag == "exhaustive")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_EXHAUSTIVE;
-    }
 
     ////////////////////////////////////////////////////////////////
     // Initialization
@@ -56,7 +42,7 @@ int hpx_main(hpx::program_options::variables_map &vm)
     // Computation
     hpxfft::shared::opt fft_computer;
     auto start_total = t.now();
-    fft_computer.initialize(std::move(values_vec), FFT_BACKEND_PLAN_FLAG);
+    fft_computer.initialize(std::move(values_vec), plan_flag);
     auto stop_init = t.now();
     values_vec = fft_computer.fft_2d_r2c();
     auto stop_total = t.now();

--- a/examples/hpxfft/shared_opt_2d.cpp
+++ b/examples/hpxfft/shared_opt_2d.cpp
@@ -1,7 +1,7 @@
-#include "hpxfft/shared/opt.hpp"            // for hpxfft::shared::opt, hpxfft::shared::vector_2d
-#include "hpxfft/util/create_dir.hpp"       // for hpxfft::util::create_parent_dir
-#include "hpxfft/util/print_vector_2d.hpp"  // for hpxfft::util::print_vector_2d
-#include <fstream>                          // for std::ofstream
+#include "hpxfft/shared/opt.hpp"         // for hpxfft::shared::opt, hpxfft::shared::vector_2d
+#include "hpxfft/util/create_dir.hpp"    // for hpxfft::util::create_parent_dir
+#include "hpxfft/util/print_vector.hpp"  // for hpxfft::util::print_vector_2d
+#include <fstream>                       // for std::ofstream
 #include <hpx/hpx_init.hpp>
 #include <numeric>  // for std::iota
 

--- a/examples/hpxfft/shared_sync_2d.cpp
+++ b/examples/hpxfft/shared_sync_2d.cpp
@@ -1,7 +1,7 @@
-#include "hpxfft/shared/sync.hpp"           // for hpxfft::shared::sync, hpxfft::shared::vector_2d
-#include "hpxfft/util/create_dir.hpp"       // for hpxfft::util::create_parent_dir
-#include "hpxfft/util/print_vector_2d.hpp"  // for hpxfft::util::print_vector_2d
-#include <fstream>                          // for std::ofstream
+#include "hpxfft/shared/sync.hpp"        // for hpxfft::shared::sync, hpxfft::shared::vector_2d
+#include "hpxfft/util/create_dir.hpp"    // for hpxfft::util::create_parent_dir
+#include "hpxfft/util/print_vector.hpp"  // for hpxfft::util::print_vector_2d
+#include <fstream>                       // for std::ofstream
 #include <hpx/hpx_init.hpp>
 #include <numeric>  // for std::iota
 

--- a/examples/hpxfft/shared_sync_2d.cpp
+++ b/examples/hpxfft/shared_sync_2d.cpp
@@ -26,20 +26,6 @@ int hpx_main(hpx::program_options::variables_map &vm)
     const std::size_t dim_c_x = vm["nx"].as<std::size_t>();  // N_X;
     const std::size_t dim_r_y = vm["ny"].as<std::size_t>();  // N_Y;
     const std::size_t dim_c_y = dim_r_y / 2 + 1;
-    // FFTW plans
-    unsigned FFT_BACKEND_PLAN_FLAG = FFTW_ESTIMATE;
-    if (plan_flag == "measure")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_MEASURE;
-    }
-    else if (plan_flag == "patient")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_PATIENT;
-    }
-    else if (plan_flag == "exhaustive")
-    {
-        FFT_BACKEND_PLAN_FLAG = FFTW_EXHAUSTIVE;
-    }
 
     ////////////////////////////////////////////////////////////////
     // Initialization
@@ -56,7 +42,7 @@ int hpx_main(hpx::program_options::variables_map &vm)
     // Computation
     hpxfft::shared::sync fft_computer;
     auto start_total = t.now();
-    fft_computer.initialize(std::move(values_vec), FFT_BACKEND_PLAN_FLAG);
+    fft_computer.initialize(std::move(values_vec), plan_flag);
     auto stop_init = t.now();
     values_vec = fft_computer.fft_2d_r2c();
     auto stop_total = t.now();

--- a/test/src/test_distributed_agas.cpp
+++ b/test/src/test_distributed_agas.cpp
@@ -40,7 +40,7 @@ int entrypoint_test1(int argc, char *argv[])
 
     // Computation
     hpxfft::distributed::agas fft;
-    unsigned plan_flag = FFTW_ESTIMATE;
+    std::string plan_flag = "estimate";
     hpx::future<void> init_future = fft.initialize(std::move(values_vec), "scatter", plan_flag);
     init_future.get();
     hpx::future<hpxfft::distributed::vector_2d> result_future = fft.fft_2d_r2c();

--- a/test/src/test_distributed_agas.cpp
+++ b/test/src/test_distributed_agas.cpp
@@ -1,5 +1,5 @@
 #include "../../core/include/hpxfft/distributed/agas.hpp"
-#include "../../core/include/hpxfft/util/print_vector_2d.hpp"
+#include "../../core/include/hpxfft/util/print_vector.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include <fftw3.h>

--- a/test/src/test_distributed_loop.cpp
+++ b/test/src/test_distributed_loop.cpp
@@ -40,7 +40,7 @@ int entrypoint_test1(int argc, char *argv[])
 
     // Computation
     hpxfft::distributed::loop fft;
-    unsigned plan_flag = FFTW_ESTIMATE;
+    std::string plan_flag = "estimate";
     fft.initialize(std::move(values_vec), "scatter", plan_flag);
     values_vec = fft.fft_2d_r2c();
     auto total = fft.get_measurement(std::string("total"));

--- a/test/src/test_distributed_loop.cpp
+++ b/test/src/test_distributed_loop.cpp
@@ -1,5 +1,5 @@
 #include "../../core/include/hpxfft/distributed/loop.hpp"
-#include "../../core/include/hpxfft/util/print_vector_2d.hpp"
+#include "../../core/include/hpxfft/util/print_vector.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include <fftw3.h>

--- a/test/src/test_naive.cpp
+++ b/test/src/test_naive.cpp
@@ -2,7 +2,6 @@
 #include "../../core/include/hpxfft/util/print_vector_2d.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
-#include <fftw3.h>
 #include <hpx/hpx_init.hpp>
 
 using hpxfft::shared::naive;
@@ -36,7 +35,7 @@ int entrypoint_test1(int argc, char *argv[])
 
     // Computation
     hpxfft::shared::naive fft;
-    unsigned plan_flag = FFTW_ESTIMATE;
+    std::string plan_flag = "estimate";
     fft.initialize(std::move(values_vec), plan_flag);
     values_vec = fft.fft_2d_r2c();
     auto total = fft.get_measurement(std::string("total"));

--- a/test/src/test_naive.cpp
+++ b/test/src/test_naive.cpp
@@ -1,5 +1,5 @@
 #include "../../core/include/hpxfft/shared/naive.hpp"
-#include "../../core/include/hpxfft/util/print_vector_2d.hpp"
+#include "../../core/include/hpxfft/util/print_vector.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include <hpx/hpx_init.hpp>

--- a/test/src/test_shared_agas.cpp
+++ b/test/src/test_shared_agas.cpp
@@ -1,5 +1,5 @@
 #include "../../core/include/hpxfft/shared/agas.hpp"
-#include "../../core/include/hpxfft/util/print_vector_2d.hpp"
+#include "../../core/include/hpxfft/util/print_vector.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include <hpx/hpx_init.hpp>

--- a/test/src/test_shared_agas.cpp
+++ b/test/src/test_shared_agas.cpp
@@ -2,7 +2,6 @@
 #include "../../core/include/hpxfft/util/print_vector_2d.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
-#include <fftw3.h>
 #include <hpx/hpx_init.hpp>
 
 using hpxfft::shared::agas;
@@ -36,7 +35,7 @@ int entrypoint_test1(int argc, char *argv[])
 
     // Computation
     hpxfft::shared::agas fft;
-    unsigned plan_flag = FFTW_MEASURE;
+    std::string plan_flag = "measure";
     hpx::future<void> init_future = fft.initialize(std::move(values_vec), plan_flag);
     init_future.get();
     hpx::future<hpxfft::shared::vector_2d> result_future = fft.fft_2d_r2c();

--- a/test/src/test_shared_loop.cpp
+++ b/test/src/test_shared_loop.cpp
@@ -2,7 +2,6 @@
 #include "../../core/include/hpxfft/util/print_vector_2d.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
-#include <fftw3.h>
 #include <hpx/hpx_init.hpp>
 
 using hpxfft::shared::loop;
@@ -45,10 +44,11 @@ int entrypoint_test1(int argc, char *argv[])
     REQUIRE(out1 == expected_output);
     */
     hpxfft::shared::loop fft2;
-    unsigned plan_flag = FFTW_ESTIMATE;
+    std::string plan_flag = "estimate";
     fft2.initialize(std::move(values_vec), plan_flag);
     hpxfft::shared::vector_2d out2 = fft2.fft_2d_r2c_par();
     auto total = fft2.get_measurement(std::string("total"));
+    auto flops = fft2.get_measurement(std::string("plan_flops"));
     REQUIRE(total >= 0.0);
     REQUIRE(out2 == expected_output);
 

--- a/test/src/test_shared_loop.cpp
+++ b/test/src/test_shared_loop.cpp
@@ -1,5 +1,5 @@
 #include "../../core/include/hpxfft/shared/loop.hpp"
-#include "../../core/include/hpxfft/util/print_vector_2d.hpp"
+#include "../../core/include/hpxfft/util/print_vector.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include <hpx/hpx_init.hpp>

--- a/test/src/test_shared_opt.cpp
+++ b/test/src/test_shared_opt.cpp
@@ -1,5 +1,5 @@
 #include "../../core/include/hpxfft/shared/opt.hpp"
-#include "../../core/include/hpxfft/util/print_vector_2d.hpp"
+#include "../../core/include/hpxfft/util/print_vector.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include <hpx/hpx_init.hpp>

--- a/test/src/test_shared_opt.cpp
+++ b/test/src/test_shared_opt.cpp
@@ -2,7 +2,6 @@
 #include "../../core/include/hpxfft/util/print_vector_2d.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
-#include <fftw3.h>
 #include <hpx/hpx_init.hpp>
 
 using hpxfft::shared::opt;
@@ -36,7 +35,7 @@ int entrypoint_test1(int argc, char *argv[])
 
     // Computation
     hpxfft::shared::opt fft;
-    unsigned plan_flag = FFTW_ESTIMATE;
+    std::string plan_flag = "estimate";
     fft.initialize(std::move(values_vec), plan_flag);
     values_vec = fft.fft_2d_r2c();
     auto total = fft.get_measurement(std::string("total"));

--- a/test/src/test_shared_sync.cpp
+++ b/test/src/test_shared_sync.cpp
@@ -1,5 +1,5 @@
 #include "../../core/include/hpxfft/shared/sync.hpp"
-#include "../../core/include/hpxfft/util/print_vector_2d.hpp"
+#include "../../core/include/hpxfft/util/print_vector.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include <hpx/hpx_init.hpp>

--- a/test/src/test_shared_sync.cpp
+++ b/test/src/test_shared_sync.cpp
@@ -2,7 +2,6 @@
 #include "../../core/include/hpxfft/util/print_vector_2d.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
-#include <fftw3.h>
 #include <hpx/hpx_init.hpp>
 
 using hpxfft::shared::sync;
@@ -36,7 +35,7 @@ int entrypoint_test1(int argc, char *argv[])
 
     // Computation
     hpxfft::shared::sync fft;
-    unsigned plan_flag = FFTW_ESTIMATE;
+    std::string plan_flag = "estimate";
     fft.initialize(std::move(values_vec), plan_flag);
     values_vec = fft.fft_2d_r2c();
     auto total = fft.get_measurement(std::string("total"));


### PR DESCRIPTION
Added a FFTW adapter to the project, to relocate the calls of FFTW to 1 instance.

- `fftw3.h` is now only imported by the adapter file
- a own struct was added for each a r2c and a c2c fft
- each HPXFFT module now has a struct for each r2c and c2c fft, which includes the plan and the execution call of the fft
- destroying and cleanup of the fftw_plans is also handled by the structs and their destructors
- the `initialize` functions of each module now do not take a fftw_plan anymore, but only a string. The options are:

1. `estimate`
2. `measure`
3. `patient`
4. `exhaustive`

the string then gets cast internally to the according `fftw_plan`

changing direction of the c2c fft from forwards to backwards is technically possible with the adapter, but isn't currrently needed, since the modules themselve are setting the direction to forward.